### PR TITLE
Assure db folders for leveldb adapter

### DIFF
--- a/api/store/create.js
+++ b/api/store/create.js
@@ -1,6 +1,9 @@
 module.exports = createStore
 
+var pathResolve = require('path').resolve
+
 var _ = require('lodash')
+var mkdirp = require('mkdirp')
 
 var addRolePrivilege = require('../utils/add-role-privilege')
 var errors = require('../utils/errors')
@@ -38,12 +41,34 @@ function createStore (state, name, options) {
     return state.metaDb.put(doc)
 
     .then(function () {
-      var db = new state.PouchDB(name)
       if (!state.usesHttpAdapter) {
+        var db = new state.PouchDB(name)
         return db.info()
+
+        // TODO: remove once https://github.com/pouchdb/pouchdb/issues/5668 is resolved
+        // also remove mkdirp from package.json unless it’s used somewhere else
+        .catch(function (error) {
+          if (error.name === 'OpenError') {
+            var path = db.__opts.prefix ? db.__opts.prefix + name : name
+            return new Promise(function (resolve, reject) {
+              mkdirp(pathResolve(path), function (error) {
+                if (error) {
+                  return reject(error)
+                }
+
+                resolve()
+              })
+            })
+
+            .then(function () {
+              return new state.PouchDB(name).info()
+            })
+          }
+          throw error
+        })
       }
 
-      return db.info().then(function () {
+      return new state.PouchDB(name).info().then(function () {
         var options = {
           couchDbUrl: state.couchDbUrl,
           dbName: name

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "h2o2": "^5.0.0",
     "hapi-to-express": "^1.2.1",
     "lodash": "^4.13.1",
+    "mkdirp": "^0.5.1",
     "pouchdb-hoodie-api": "^1.6.2",
     "request": "^2.69.0",
     "to-id": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "boom": "^4.0.0",
     "express": "^4.13.4",
-    "express-pouchdb": "^1.0.2",
+    "express-pouchdb": "^2.0.0",
     "h2o2": "^5.0.0",
     "hapi-to-express": "^1.2.1",
     "lodash": "^4.13.1",


### PR DESCRIPTION
Workaround for https://github.com/pouchdb/pouchdb/issues/5668
ping @hoodiehq/maintainers

Note: this also needs hoodiehq/hoodie-server#507 to work properly