### PR TITLE
@gr2m/hapi-to-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "express": "^4.13.4",
     "express-pouchdb": "^2.0.0",
     "h2o2": "^5.0.0",
-    "hapi-to-express": "^1.2.1",
+    "@gr2m/hapi-to-express": "1.2.1-includes-6",
     "lodash": "^4.13.1",
     "mkdirp": "^0.5.1",
     "pouchdb-hoodie-api": "^1.6.2",


### PR DESCRIPTION
Workaround until https://github.com/jakepruitt/hapi-to-express/pull/6 is released. See also: https://github.com/jakepruitt/hapi-to-express/issues/5