### PR TITLE
test(replicate): Ensure that autorequire replicate plugin covered

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pouchdb-adapter-memory": "^6.0.7",
     "pouchdb-core": "^6.0.7",
     "pouchdb-replication": "^6.0.7",
+    "proxyquire": "^1.7.10",
     "semantic-release": "^6.0.3",
     "standard": "^8.0.0",
     "tap": "^7.0.0"

--- a/test/unit/api/autorequire-pouchdb-replication-test.js
+++ b/test/unit/api/autorequire-pouchdb-replication-test.js
@@ -1,0 +1,26 @@
+var test = require('tap').test
+var proxyquire = require('proxyquire').noPreserveCache()
+var state = {}
+
+state.PouchDB = function () {
+  return {}
+}
+
+state.PouchDB.plugin = function () {}
+
+test('Store replicate function', function (group) {
+  group.test('Returns a promise rejection when the module is not found', function (t) {
+    var replicate = proxyquire('../../../api/store/replicate', {'pouchdb-replication': null})
+    t.plan(1)
+    replicate(state)
+      .then(function () {
+        t.fail('Replicate function should not return a fulfilled promise')
+        t.end()
+      })
+      .catch(function (error) {
+        t.ok(error, 'Replicate returns rejected promise')
+        t.end()
+      })
+  })
+  group.end()
+})

--- a/test/unit/api/autorequire-pouchdb-replication-test.js
+++ b/test/unit/api/autorequire-pouchdb-replication-test.js
@@ -1,6 +1,7 @@
 var test = require('tap').test
 var proxyquire = require('proxyquire').noPreserveCache()
 var state = {}
+var errors = require('../../../api/utils/errors')
 
 state.PouchDB = function () {
   return {}
@@ -10,7 +11,9 @@ state.PouchDB.plugin = function () {}
 
 test('Store replicate function', function (group) {
   group.test('Returns a promise rejection when the module is not found', function (t) {
-    var replicate = proxyquire('../../../api/store/replicate', {'pouchdb-replication': null})
+    var replicate = proxyquire('../../../api/store/replicate', {
+      'pouchdb-replication': null
+    })
     t.plan(1)
     replicate(state)
       .then(function () {
@@ -18,7 +21,8 @@ test('Store replicate function', function (group) {
         t.end()
       })
       .catch(function (error) {
-        t.ok(error, 'Replicate returns rejected promise')
+        t.same(error, errors.REPLICATION_PACKAGE_MISSING,
+          'Replicate returns rejected promise with package missing error')
         t.end()
       })
   })


### PR DESCRIPTION
New dev-dependency - proxyquire.
Add test unit/api/autorequire-pouchdb-replication-test.js to cover missing
module error resulting in a rejected promise.