### PR TITLE
conditional server.register of h2o2 plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ function hapiCouchDbStore (server, options, next) {
   if (api.adapter === 'http') {
     // workaround for https://github.com/pouchdb/pouchdb/issues/5548
     var couchDbUrl = toCouchDbUrl(new options.PouchDB('hack', {skip_setup: true}).__opts)
-    server.register(require('h2o2'))
+    server.register({
+      register: require('h2o2'),
+      once: true
+    })
   } else {
     var xapp = require('express-pouchdb')(options.PouchDB, {
       mode: 'minimumForPouchDB'


### PR DESCRIPTION
without the `once: true` there is a `UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Plugin h2o2 already registered` error when run against CouchDB